### PR TITLE
Add notification template management

### DIFF
--- a/Modules/Notification/Http/Controllers/NotificationTemplateController.php
+++ b/Modules/Notification/Http/Controllers/NotificationTemplateController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Modules\Notification\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Modules\Notification\Models\NotificationTemplate;
+
+class NotificationTemplateController extends Controller
+{
+    public function index()
+    {
+        $templates = NotificationTemplate::paginate(10);
+        return view('notification::admin.templates.index', compact('templates'));
+    }
+
+    public function create()
+    {
+        return view('notification::admin.templates.create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'key' => 'required|string|max:255|unique:notification_templates,key',
+            'notification_type' => 'required|string|max:255',
+            'channels' => 'required|array',
+            'content' => 'nullable',
+            'actions' => 'nullable',
+            'is_active' => 'nullable|boolean',
+        ]);
+
+        $data['channels'] = array_values($data['channels']);
+        $data['is_active'] = $request->boolean('is_active');
+
+        NotificationTemplate::create($data);
+        message();
+        return redirect()->route('admin.notification-templates.index');
+    }
+
+    public function edit(NotificationTemplate $notificationTemplate)
+    {
+        return view('notification::admin.templates.edit', ['template' => $notificationTemplate]);
+    }
+
+    public function update(Request $request, NotificationTemplate $notificationTemplate)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'key' => 'required|string|max:255|unique:notification_templates,key,' . $notificationTemplate->id,
+            'notification_type' => 'required|string|max:255',
+            'channels' => 'required|array',
+            'content' => 'nullable',
+            'actions' => 'nullable',
+            'is_active' => 'nullable|boolean',
+        ]);
+
+        $data['channels'] = array_values($data['channels']);
+        $data['is_active'] = $request->boolean('is_active');
+
+        $notificationTemplate->update($data);
+        message();
+        return redirect()->route('admin.notification-templates.edit', $notificationTemplate->id);
+    }
+
+    public function destroy(NotificationTemplate $notificationTemplate)
+    {
+        $notificationTemplate->delete();
+        return back()->with('success', 'Template deleted');
+    }
+}

--- a/Modules/Notification/Providers/NotificationServiceProvider.php
+++ b/Modules/Notification/Providers/NotificationServiceProvider.php
@@ -37,6 +37,11 @@ class NotificationServiceProvider extends ServiceProvider
         $this->registerConfig();
         $this->registerViews();
         $this->loadMigrationsFrom(module_path($this->moduleName, 'database/migrations'));
+
+        // Register admin panel menu
+        if (class_exists(\Modules\Notification\Menus\NotificationMenu::class)) {
+            \Modules\Notification\Menus\NotificationMenu::register();
+        }
         
         // Register scheduled tasks
         $this->app->booted(function () {

--- a/Modules/Notification/app/Menus/NotificationMenu.php
+++ b/Modules/Notification/app/Menus/NotificationMenu.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Modules\Notification\Menus;
+
+use Modules\Core\Services\MenuManager;
+
+class NotificationMenu
+{
+    public static function register(): void
+    {
+        MenuManager::add([
+            'type' => 'heading',
+            'title' => 'اعلان‌ها',
+            'priority' => 50,
+        ]);
+
+        MenuManager::add([
+            'title' => 'لیست اعلان‌ها',
+            'icon' => 'ki-duotone ki-notification-on fs-2',
+            'route' => 'admin.notifications.index',
+            'priority' => 51,
+        ]);
+
+        MenuManager::add([
+            'title' => 'قالب‌های اعلان',
+            'icon' => 'ki-duotone ki-setting-3 fs-2',
+            'route' => 'admin.notification-templates.index',
+            'priority' => 52,
+        ]);
+    }
+}

--- a/Modules/Notification/resources/views/admin/templates/create.blade.php
+++ b/Modules/Notification/resources/views/admin/templates/create.blade.php
@@ -1,0 +1,57 @@
+@extends('core::admin.layout.master')
+
+@section('content')
+    <x-core::form.page-header resource="قالب اعلان" page="ایجاد" />
+
+    <div id="kt_app_content" class="app-content flex-column-fluid">
+        <div id="kt_app_content_container" class="app-container container-fluid">
+            <form class="form" method="post" action="{{ route('admin.notification-templates.store') }}">
+                @csrf
+                <div class="card card-flush py-4">
+                    <div class="card-body pt-0">
+                        <div class="row">
+                            <div class="col-md-6 mb-7">
+                                <x-core::form.input name="name" title="عنوان" required="true" />
+                            </div>
+                            <div class="col-md-6 mb-7">
+                                <x-core::form.input name="key" title="کلید" required="true" />
+                            </div>
+                            <div class="col-md-6 mb-7">
+                                <x-core::form.input name="notification_type" title="نوع" required="true" />
+                            </div>
+                            <div class="col-md-6 mb-7">
+                                <label class="required form-label">کانال‌ها</label>
+                                <select name="channels[]" class="form-select" data-control="select2" data-placeholder="انتخاب کنید" multiple required>
+                                    <option value="database">database</option>
+                                    <option value="mail">mail</option>
+                                    <option value="sms">sms</option>
+                                    <option value="whatsapp">whatsapp</option>
+                                    <option value="telegram">telegram</option>
+                                </select>
+                            </div>
+                            <div class="col-12 mb-7">
+                                <label class="form-label">محتوا (JSON)</label>
+                                <textarea name="content" class="form-control" rows="4">{{ old('content') }}</textarea>
+                            </div>
+                            <div class="col-12 mb-7">
+                                <label class="form-label">عملیات (JSON)</label>
+                                <textarea name="actions" class="form-control" rows="4">{{ old('actions') }}</textarea>
+                            </div>
+                            <div class="col-12">
+                                <label class="form-check form-switch form-check-custom form-check-solid">
+                                    <input class="form-check-input" type="checkbox" name="is_active" value="1" checked>
+                                    <span class="form-check-label">فعال باشد</span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex justify-content-end mt-5">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="ki-duotone ki-check fs-2 me-2"></i> ذخیره
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/Modules/Notification/resources/views/admin/templates/edit.blade.php
+++ b/Modules/Notification/resources/views/admin/templates/edit.blade.php
@@ -1,0 +1,58 @@
+@extends('core::admin.layout.master')
+
+@section('content')
+    <x-core::form.page-header resource="قالب اعلان" page="ویرایش" />
+
+    <div id="kt_app_content" class="app-content flex-column-fluid">
+        <div id="kt_app_content_container" class="app-container container-fluid">
+            <form class="form" method="post" action="{{ route('admin.notification-templates.update', $template->id) }}">
+                @csrf
+                @method('PUT')
+                <div class="card card-flush py-4">
+                    <div class="card-body pt-0">
+                        <div class="row">
+                            <div class="col-md-6 mb-7">
+                                <x-core::form.input name="name" title="عنوان" required="true" :value="$template->name" />
+                            </div>
+                            <div class="col-md-6 mb-7">
+                                <x-core::form.input name="key" title="کلید" required="true" :value="$template->key" />
+                            </div>
+                            <div class="col-md-6 mb-7">
+                                <x-core::form.input name="notification_type" title="نوع" required="true" :value="$template->notification_type" />
+                            </div>
+                            <div class="col-md-6 mb-7">
+                                <label class="required form-label">کانال‌ها</label>
+                                <select name="channels[]" class="form-select" data-control="select2" data-placeholder="انتخاب کنید" multiple required>
+                                    <option value="database" {{ in_array('database', $template->channels ?? []) ? 'selected' : '' }}>database</option>
+                                    <option value="mail" {{ in_array('mail', $template->channels ?? []) ? 'selected' : '' }}>mail</option>
+                                    <option value="sms" {{ in_array('sms', $template->channels ?? []) ? 'selected' : '' }}>sms</option>
+                                    <option value="whatsapp" {{ in_array('whatsapp', $template->channels ?? []) ? 'selected' : '' }}>whatsapp</option>
+                                    <option value="telegram" {{ in_array('telegram', $template->channels ?? []) ? 'selected' : '' }}>telegram</option>
+                                </select>
+                            </div>
+                            <div class="col-12 mb-7">
+                                <label class="form-label">محتوا (JSON)</label>
+                                <textarea name="content" class="form-control" rows="4">{{ old('content', json_encode($template->content)) }}</textarea>
+                            </div>
+                            <div class="col-12 mb-7">
+                                <label class="form-label">عملیات (JSON)</label>
+                                <textarea name="actions" class="form-control" rows="4">{{ old('actions', json_encode($template->actions)) }}</textarea>
+                            </div>
+                            <div class="col-12">
+                                <label class="form-check form-switch form-check-custom form-check-solid">
+                                    <input class="form-check-input" type="checkbox" name="is_active" value="1" {{ $template->is_active ? 'checked' : '' }}>
+                                    <span class="form-check-label">فعال باشد</span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex justify-content-end mt-5">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="ki-duotone ki-check fs-2 me-2"></i> ذخیره
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/Modules/Notification/resources/views/admin/templates/index.blade.php
+++ b/Modules/Notification/resources/views/admin/templates/index.blade.php
@@ -1,0 +1,84 @@
+@extends('core::admin.layout.master')
+
+@section('content')
+    <div class="card">
+        <div class="card-header border-0 pt-6">
+            <div class="card-title">
+                <h2 class="fw-bold">قالب‌های اعلان</h2>
+            </div>
+            <div class="card-toolbar">
+                <div class="d-flex justify-content-end" data-kt-customer-table-toolbar="base">
+                    <a href="{{ route('admin.notification-templates.create') }}" class="btn btn-primary">
+                        <i class="ki-duotone ki-plus fs-2"></i>
+                        ایجاد قالب جدید
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="card-body pt-0">
+            <table class="table align-middle table-row-dashed fs-6 gy-5" id="kt_templates_table">
+                <thead>
+                <tr class="text-start text-gray-400 fw-bold fs-7 text-uppercase gs-0">
+                    <th class="min-w-50px">شناسه</th>
+                    <th class="min-w-125px">عنوان</th>
+                    <th class="min-w-125px">کلید</th>
+                    <th class="min-w-125px">نوع</th>
+                    <th class="min-w-125px">وضعیت</th>
+                    <th class="text-end min-w-70px">عملیات</th>
+                </tr>
+                </thead>
+                <tbody class="fw-semibold text-gray-600">
+                @foreach($templates as $template)
+                    <tr>
+                        <td>{{ $template->id }}</td>
+                        <td>{{ $template->name }}</td>
+                        <td>{{ $template->key }}</td>
+                        <td>{{ $template->notification_type }}</td>
+                        <td>
+                            @if($template->is_active)
+                                <span class="badge badge-light-success">فعال</span>
+                            @else
+                                <span class="badge badge-light-danger">غیرفعال</span>
+                            @endif
+                        </td>
+                        <td class="text-end">
+                            <a href="#" class="btn btn-sm btn-light btn-flex btn-center btn-active-light-primary" data-kt-menu-trigger="click" data-kt-menu-placement="bottom-end">
+                                عملیات
+                                <i class="ki-duotone ki-down fs-5 ms-1"></i>
+                            </a>
+                            <div class="menu menu-sub menu-sub-dropdown menu-column menu-rounded menu-gray-600 menu-state-bg-light-primary fw-semibold fs-7 w-125px py-4" data-kt-menu="true">
+                                <div class="menu-item px-3">
+                                    <a href="{{ route('admin.notification-templates.edit', $template->id) }}" class="menu-link px-3">ویرایش</a>
+                                </div>
+                                <div class="menu-item px-3">
+                                    <a href="#" class="menu-link px-3 text-danger" onclick="event.preventDefault(); if(confirm('آیا مطمئن هستید؟')) document.getElementById('delete-form-{{ $template->id }}').submit();">حذف</a>
+                                    <form id="delete-form-{{ $template->id }}" action="{{ route('admin.notification-templates.destroy', $template->id) }}" method="POST" style="display: none;">
+                                        @csrf
+                                        @method('DELETE')
+                                    </form>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                @endforeach
+                </tbody>
+            </table>
+            <div class="d-flex justify-content-end">
+                {{ $templates->links() }}
+            </div>
+        </div>
+    </div>
+@endsection
+
+@push('scripts')
+<script>
+    const table = document.querySelector('#kt_templates_table');
+    $(table).DataTable({
+        "info": false,
+        'order': [],
+        'columnDefs': [
+            { orderable: false, targets: 5 },
+        ]
+    });
+</script>
+@endpush

--- a/Modules/Notification/routes/web.php
+++ b/Modules/Notification/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Modules\Notification\Http\Controllers\NotificationController;
+use Modules\Notification\Http\Controllers\NotificationTemplateController;
 
 /*
 |--------------------------------------------------------------------------
@@ -22,6 +23,16 @@ Route::prefix('admin/notifications')->middleware(['web'])->name('admin.notificat
     Route::post('/{id}/retry', [NotificationController::class, 'retry'])->name('retry');
     Route::get('/{id}', [NotificationController::class, 'show'])->name('show');
     Route::delete('/{id}', [NotificationController::class, 'destroy'])->name('destroy');
+});
+
+// Notification template management
+Route::prefix('admin/notification-templates')->middleware(['web'])->name('admin.notification-templates.')->group(function () {
+    Route::get('/', [NotificationTemplateController::class, 'index'])->name('index');
+    Route::get('/create', [NotificationTemplateController::class, 'create'])->name('create');
+    Route::post('/', [NotificationTemplateController::class, 'store'])->name('store');
+    Route::get('/{notificationTemplate}/edit', [NotificationTemplateController::class, 'edit'])->name('edit');
+    Route::put('/{notificationTemplate}', [NotificationTemplateController::class, 'update'])->name('update');
+    Route::delete('/{notificationTemplate}', [NotificationTemplateController::class, 'destroy'])->name('destroy');
 });
 
 // User notification preferences routes


### PR DESCRIPTION
## Summary
- add NotificationMenu to register module menu items
- register NotificationMenu in notification provider
- create NotificationTemplateController CRUD
- expose notification templates routes
- add views for listing, creating and editing notification templates

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684090bdb574832d94cbd0c1fc35de49